### PR TITLE
Merge multievent support into master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ options. conf.json includes several useful options you can set:
     *    \> - sleeping because we haven't reached startTime yet today.
     *    ~ - sleeping because it's a skip day
     *    X - device failure.
+*   multiEvent - if true, calblink will check the next two events, and if they are
+    both in the time frame to show, it will show both.
 
 An example file:
 
@@ -122,6 +124,7 @@ An example file:
         "pollInterval": 60,
         "calendar": "username@example.com",
         "responseState": "accepted"
+        "multiEvent": "true"
     }
 ```
 
@@ -129,7 +132,7 @@ An example file:
 
 ## Known Issues
 
-*   If there are more than 10 events that are skipped (all-day events, excluded
+*   If there are more than 20 events that are skipped (all-day events, excluded
     events, and events with the wrong responseState) before the event that
     should be shown, the event will not be processed.
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ LED to change colors based on your next meeting. The colors it will use are:
 To use calblink, you need the following:
 
 1.  A blink(1) from [ThingM](http://blink1.thingm.com/) - calblink supports
-    mk1, mk2, and mk3 blink(1).  Note that setting up a mk3 is a bit more complicated
-    due to a bug in the go-blink1 library.
+    mk1, mk2, and mk3 blink(1).
 1.  A place to connect the blink(1) where you can see it.
 2.  The latest version of [Go](https://golang.org/).
 3.  The calblink code, found in this directory.
-4.  libusb. The [go-blink1](https://github.com/hink/go-blink1) page has details.
+4.  libusb-compat. The [go-blink1](https://github.com/kazrakcom/go-blink1) page has
+    details.
 5.  A directory to run this in.
 6.  A few go packages, which we'll install later in the Setup section.
 7.  A Google Calendar account.
@@ -37,28 +37,17 @@ To use calblink, you need the following:
 
 1.  Install Go, and plug your blink(1) in somewhere that you can see it.
 2.  Bring up a command-line window, and create the directory you want to run
-    this in. Set the GOPATH environment variable to point to this directory.
+    this in.
 3.  Put calblink.go into the directory you just created.
-4.  Install libusb, if needed. If you needed to, and used Homebrew as instructed
+4.  Install libusb-compat, if needed. If you needed to, and used Homebrew as instructed
     above, set INCLUDE\_PATH and LIBRARY\_PATH to point to the 'include' and
-    'lib' directories under the Homebrew directory.
-5.  Install the Google APIs for Go:
-
+    'lib' directories under the Homebrew directory. 
+5.  Create your module file:
     ```
-    go get -u google.golang.org/api/calendar/v3
-    go get -u golang.org/x/oauth2/...
-    ```
-
-6.  Install the blink(1) library for Go:
-
-    ```
-    go get github.com/hink/go-blink1
+    go mod init calblink
+    go mod tidy
     ```
     
-6.  Note: If you are using a mk3 blink(1), you need to integrate [this pull
-    request](https://github.com/hink/go-blink1/pull/8) to fix an issue in the go-blink1
-    library.
-
 7.  Get an OAuth 2 ID as described in step 1 of the [Google Calendar
     Quickstart](https://developers.google.com/google-apps/calendar/quickstart/go).
     Put the client\_secret.json file in your GOPATH directory.
@@ -140,14 +129,9 @@ An example file:
 
 ## Known Issues
 
-*   I have not done any special handling for Daylight Saving Time. There may
-    be edge cases with sleeping around the DST change.
 *   If there are more than 10 events that are skipped (all-day events, excluded
     events, and events with the wrong responseState) before the event that
     should be shown, the event will not be processed.
-*   If the computer goes to sleep while calblink is sleeping, calblink will oversleep.
-    The best current workaround is to kill and restart calblink upon waking from sleep.
-*   There are issues with the mk3 Blink(1) unless the patch mentioned above is in place.
 
 ## Troubleshooting
 

--- a/calblink.go
+++ b/calblink.go
@@ -31,7 +31,7 @@ import (
 	"syscall"
 	"time"
 
-	blink1 "github.com/hink/go-blink1"
+	blink1 "github.com/kazrakcom/go-blink1"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"


### PR DESCRIPTION
Multievent support adds the ability to use the two LEDs in a mk2 or mk3 blink(1) to show status of two separate events, if both are within the timeframe that they would appear.

One functionality change: when multievent is active and an event would be flashing blue/red to indicate it is starting now, and there is a second event showing, the flash will be blue/black.