### PR TITLE
Tell the JSON decoder to fail if it finds unknown fields, instead of ignoring them.

### DIFF
--- a/calblink.go
+++ b/calblink.go
@@ -610,6 +610,7 @@ func readUserPrefs() *userPrefs {
 	}
 	prefs := prefLayout{}
 	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&prefs)
 	fmt.Fprintf(debugOut, "Decoded prefs: %v\n", prefs)
 	if err != nil {


### PR DESCRIPTION
This fixes the issue where a typo in your config file will just be silently ignored.

Resolves #39 