### PR TITLE
Add support for priorityFlashSide option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ options. conf.json includes several useful options you can set:
     *    X - device failure.
 *   multiEvent - if true, calblink will check the next two events, and if they are
     both in the time frame to show, it will show both.
+*   priorityFlashSide - if 0 (the default), which side of the blink(1) is flashing
+    will not be adjusted.  If set to 1, then flashing will be prioritized on LED 1;
+	if 2, flashing will be prioritized on LED2.  Any other values are undefined.
 
 An example file:
 
@@ -130,8 +133,9 @@ An example file:
         "endTime": "18:00",
         "pollInterval": 60,
         "calendars": ["primary", "username@example.com"],
-        "responseState": "accepted"
-        "multiEvent": "true"
+        "responseState": "accepted",
+        "multiEvent": "true",
+        "priorityFlashSide": 1
     }
 ```
 


### PR DESCRIPTION
This option lets the user specify that a given LED should always be prioritized when flashing, to make it more noticeable.

This avoids the issue where, for example, if the user is in a meeting and has another starting within 5 minutes, the flashing may be on the bottom of the device and more easily missed.

A value of 1 means to prioritize LED1, a value of 2 means to prioritize LED2.  Any other value is treated as not having priority set.