### PR TITLE
Enhance Security: Implement File Permission Check for Client Secret File

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ An example file:
 
 (Yes, the curly braces are required.  Sorry.  It's a JSON dictionary.)
 
+
+
+
+### New Requirements
+In addition to the existing setup, please ensure the following requirements are met:
+
+1. **File Permission Check**: The client secret file (`client_secret.json`) must have restricted permissions to ensure sensitive credentials are protected.
+
+### Why This Change is Necessary
+Ensuring that sensitive files, such as client secret files containing authentication credentials, are accessible only by authorized users is crucial for preventing unauthorized access and potential security breaches. By implementing a file permission check, we mitigate the risk of exposing sensitive information to unauthorized users or processes.
+
+### Configuration Notes:
+To comply with the new security measure and meet the new requirements, please follow these configuration steps:
+
+1. **File Permission Requirement**: 
+    - Ensure that the client secret file (`client_secret.json`) is only readable by the owner. This can be achieved by setting appropriate file permissions using the `chmod` command. For example:
+      ```
+      chmod 600 client_secret.json
+      ```
+    This command restricts read and write permissions to the owner only, ensuring that sensitive credentials are protected from unauthorized access.
+
 ## Known Issues
 
 *   Occasionally the shutdown is not as clean as it should be.

--- a/calblink.go
+++ b/calblink.go
@@ -944,7 +944,7 @@ func main() {
 	if *debugFlag {
 		debugOut = os.Stdout
 	}
-	clientSecretPath := "/path/to/client_secret.json"
+	clientSecretPath := clientSecretFlag
 	credentials, err := loadClientCredentials(clientSecretPath)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -1065,5 +1065,5 @@ func main() {
 		sleep(time.Duration(userPrefs.pollInterval) * time.Second)
 	}
 	
-}
+
 }

--- a/calblink.go
+++ b/calblink.go
@@ -73,6 +73,39 @@ import (
 // MultiEvent indicates whether to show two events if there are multiple events in the time range.
 
 // responseState is an enumerated list of event response states, used to control which events will activate the blink(1).
+
+type ClientCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+func loadClientCredentials(clientSecretPath string) (*ClientCredentials, error) {
+	// Check if the file exists and is readable
+	info, err := os.Stat(clientSecretPath)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("client secret file not found: %s", clientSecretPath)
+	}
+
+	// Check if the file has secure permissions (readable only by owner)
+	if info.Mode().Perm() != 0400 {
+		return nil, fmt.Errorf("insecure permissions for client secret file: %s", clientSecretPath)
+	}
+
+	// Read the contents of the file
+	content, err := ioutil.ReadFile(clientSecretPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read client secret file: %v", err)
+	}
+
+	// Parse the JSON data
+	var credentials ClientCredentials
+	if err := json.Unmarshal(content, &credentials); err != nil {
+		return nil, fmt.Errorf("failed to parse client secret file: %v", err)
+	}
+
+	return &credentials, nil
+}
+
 type responseState string
 
 const (
@@ -1023,4 +1056,13 @@ func main() {
 		fmt.Fprint(dotOut, ".")
 		sleep(time.Duration(userPrefs.pollInterval) * time.Second)
 	}
+	clientSecretPath := "/path/to/client_secret.json"
+	credentials, err := loadClientCredentials(clientSecretPath)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	// Use the credentials to authenticate with the Google Calendar API
+}
 }

--- a/calblink.go
+++ b/calblink.go
@@ -935,7 +935,7 @@ func main() {
 		debugOut = os.Stdout
 	}
 	clientSecretPath := clientSecretFlag
-	b, err := ioutil.ReadFile(*clientSecretFlag)
+	credentials, err := loadClientCredentials(clientSecretPath)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -971,7 +971,7 @@ func main() {
 	// BEGIN GOOGLE CALENDAR API SAMPLE CODE
 	ctx := context.Background()
 
-	b, err := ioutil.ReadFile(*clientSecretFlag)
+	b, err := loadClientCredentials(*clientSecretFlag)
 	if err != nil {
 		log.Fatalf("Unable to read client secret file: %v", err)
 	}

--- a/calblink.go
+++ b/calblink.go
@@ -74,12 +74,7 @@ import (
 
 // responseState is an enumerated list of event response states, used to control which events will activate the blink(1).
 
-type ClientCredentials struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-func loadClientCredentials(clientSecretPath string) (*ClientCredentials, error) {
+func loadClientCredentials(clientSecretPath string) ([]byte, error) {
 	// Check if the file exists and is readable
 	info, err := os.Stat(clientSecretPath)
 	if os.IsNotExist(err) {
@@ -97,14 +92,9 @@ func loadClientCredentials(clientSecretPath string) (*ClientCredentials, error) 
 		return nil, fmt.Errorf("failed to read client secret file: %v", err)
 	}
 
-	// Parse the JSON data
-	var credentials ClientCredentials
-	if err := json.Unmarshal(content, &credentials); err != nil {
-		return nil, fmt.Errorf("failed to parse client secret file: %v", err)
-	}
-
-	return &credentials, nil
+	return content, nil
 }
+
 
 type responseState string
 
@@ -945,7 +935,7 @@ func main() {
 		debugOut = os.Stdout
 	}
 	clientSecretPath := clientSecretFlag
-	credentials, err := loadClientCredentials(clientSecretPath)
+	b, err := ioutil.ReadFile(*clientSecretFlag)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return

--- a/calblink.go
+++ b/calblink.go
@@ -934,15 +934,7 @@ func main() {
 	if *debugFlag {
 		debugOut = os.Stdout
 	}
-	clientSecretPath := clientSecretFlag
-	credentials, err := loadClientCredentials(clientSecretPath)
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
-
-	// Use the credentials to authenticate with the Google Calendar API
-
+	
 	userPrefs := readUserPrefs()
 
 	// Overrides from command-line

--- a/calblink.go
+++ b/calblink.go
@@ -944,6 +944,14 @@ func main() {
 	if *debugFlag {
 		debugOut = os.Stdout
 	}
+	clientSecretPath := "/path/to/client_secret.json"
+	credentials, err := loadClientCredentials(clientSecretPath)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	// Use the credentials to authenticate with the Google Calendar API
 
 	userPrefs := readUserPrefs()
 
@@ -1056,13 +1064,6 @@ func main() {
 		fmt.Fprint(dotOut, ".")
 		sleep(time.Duration(userPrefs.pollInterval) * time.Second)
 	}
-	clientSecretPath := "/path/to/client_secret.json"
-	credentials, err := loadClientCredentials(clientSecretPath)
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
-
-	// Use the credentials to authenticate with the Google Calendar API
+	
 }
 }


### PR DESCRIPTION
Changes Made
Added file permission check to ensure the client secret file is readable only by the owner.
Added the loadClientCredentials function to verify file permissions before reading the file contents.
Purpose
The purpose of this pull request is to enhance the security of the Go code by enforcing strict file permissions for the client secret file used for authentication with the Google Calendar API.

Why This Change is Necessary
Ensuring that sensitive files, such as client secret files containing authentication credentials, are accessible only by authorized users is crucial for preventing unauthorized access and potential security breaches. By implementing a file permission check, we mitigate the risk of exposing sensitive information to unauthorized users or processes.