### PR TITLE
ioutil is deprecated, plus minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ To use calblink, you need the following:
     go mod init calblink
     go mod tidy
     ```
-    
+6. If you already have a `go.mod` and `go.sum`, you may need to update it before compiling.
+    ```
+    go get -u
+    go mod tidy
+    ```
 7.  Get an OAuth 2 ID as described in step 1 of the [Google Calendar
     Quickstart](https://developers.google.com/google-apps/calendar/quickstart/go).
     Put the client\_secret.json file in your GOPATH directory.
@@ -57,25 +61,25 @@ To use calblink, you need the following:
     * For a default Homebrew install on an Intel-based Mac:
     
             CGO_LDFLAGS="-L/usr/local/lib" CGO_CFLAGS="-I/usr/local/include" go build calblink.go
- 	* For a default Homebrew install on an ARM-based Mac:
- 	
-			CGO_LDFLAGS="-L/opt/homebrew/lib" CGO_CFLAGS="-I/opt/homebrew/include" go build calblink.go
-	* For a customized Homebrew install, modify the above to match your configuration.
-        
-8.  Run the calblink program:
+    * For a default Homebrew install on an ARM-based Mac:
+    
+            CGO_LDFLAGS="-L/opt/homebrew/lib" CGO_CFLAGS="-I/opt/homebrew/include" go build calblink.go
+    * For a customized Homebrew install, modify the above to match your configuration.
+
+9.  Run the calblink program:
 
         ./calblink
 
-9.  It will request that you go to a URL. On macOS, it will also request that you allow
+10. It will request that you go to a URL. On macOS, it will also request that you allow
     the program to receive network requests; you should allow this.  You should access
     this URL from the account you want to read the calendar of.
 
-10. That's it! It should just run now, and set your blink(1) to change color
+11. That's it! It should just run now, and set your blink(1) to change color
     appropriately. To quit out of it, hit Ctrl-C in the window you ran it in.
     (It will turn the blink(1) off automatically.) It will output a . into the
     terminal window every time it checks the server and sets the LED.
 
-11. Optionally, set up a config file, as below.
+12. Optionally, set up a config file, as below.
 
 ## What are the configuration options?
 
@@ -160,9 +164,6 @@ An example file:
 ```
 
 (Yes, the curly braces are required.  Sorry.  It's a JSON dictionary.)
-
-
-
 
 ### New Requirements
 In addition to the existing setup, please ensure the following requirements are met:

--- a/calblink.go
+++ b/calblink.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -87,14 +86,13 @@ func loadClientCredentials(clientSecretPath string) ([]byte, error) {
 	}
 
 	// Read the contents of the file
-	content, err := ioutil.ReadFile(clientSecretPath)
+	content, err := os.ReadFile(clientSecretPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read client secret file: %v", err)
 	}
 
 	return content, nil
 }
-
 
 type responseState string
 
@@ -131,8 +129,9 @@ func (state responseState) isValidState() bool {
 	return false
 }
 
-// workSiteType is an enumerated list of 
+// workSiteType is an enumerated list of
 type workSiteType int
+
 const (
 	workSiteHome workSiteType = iota
 	workSiteOffice
@@ -165,7 +164,7 @@ func (siteType workSiteType) toString() string {
 // all sites of the given type.
 type workSite struct {
 	siteType workSiteType
-	name string
+	name     string
 }
 
 // Converts a string into a workSite structure.  Returns an unset structure if the string is invalid.
@@ -252,8 +251,8 @@ var responseStateFlag = flag.String("response_state", "notRejected", "Which even
 var deviceFailureRetriesFlag = flag.Int("device_failure_retries", 10, "Number of times to retry initializing the device before quitting the program")
 var showDotsFlag = flag.Bool("show_dots", true, "Whether to show progress dots after every cycle of checking the calendar")
 
-var debugOut io.Writer = ioutil.Discard
-var dotOut io.Writer = ioutil.Discard
+var debugOut io.Writer = io.Discard
+var dotOut io.Writer = io.Discard
 
 const failureRetries = 3
 
@@ -565,7 +564,7 @@ func nextEvent(items []*calendar.Event, locations []workSite, userPrefs *userPre
 		for _, location := range locations {
 			locationSet[location] = true
 		}
-	
+
 		for _, prefLocation := range userPrefs.workingLocations {
 			if locationSet[prefLocation] {
 				fmt.Fprintf(debugOut, "Found matching location: %v\n", prefLocation)
@@ -573,7 +572,7 @@ func nextEvent(items []*calendar.Event, locations []workSite, userPrefs *userPre
 				break
 			}
 		}
-		
+
 		if !match {
 			fmt.Fprintf(debugOut, "Skipping all events due to no matching locations in %v\n", locations)
 			return events
@@ -878,7 +877,7 @@ func printStartInfo(userPrefs *userPrefs) {
 			if item.siteType == workSiteHome {
 				fmt.Printf("   Home\n")
 			} else {
-			  	fmt.Printf("   %v: %v\n", item.siteType.toString(), item.name)
+				fmt.Printf("   %v: %v\n", item.siteType.toString(), item.name)
 			}
 		}
 	}
@@ -934,7 +933,7 @@ func main() {
 	if *debugFlag {
 		debugOut = os.Stdout
 	}
-	
+
 	userPrefs := readUserPrefs()
 
 	// Overrides from command-line
@@ -1046,6 +1045,5 @@ func main() {
 		fmt.Fprint(dotOut, ".")
 		sleep(time.Duration(userPrefs.pollInterval) * time.Second)
 	}
-	
 
 }


### PR DESCRIPTION
Remove `io/ioutil` since it has been deprecated for a very long time.
Minor tweaks to the README.