### PR TITLE
Major update to add the ability to run calblink as a service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,44 +45,50 @@ To use calblink, you need the following:
     go mod init calblink
     go mod tidy
     ```
+6.  If you already have a `go.mod` and `go.sum`, you may need to update it
+    before compiling.
+    ```
+    go get -u
+    go mod tidy
+    ```
     
 7.  Get an OAuth 2 ID as described in step 1 of the [Google Calendar
     Quickstart](https://developers.google.com/google-apps/calendar/quickstart/go).
     Put the client\_secret.json file in your GOPATH directory.
     
-7.  Make sure the client\_secret.json file is secure by changing its permissions
+8.  Make sure the client\_secret.json file is secure by changing its permissions
     to only allow the user to read it:
     
         chmod 600 client_secret.json
 
-8.  Build the calblink program as appropriate for your environment:
+9.  Build the calblink program as appropriate for your environment:
     * For a Linux environment or another that doesn't use Homebrew:
     
             go build
     * For a default Homebrew install on an Intel-based Mac:
     
             CGO_LDFLAGS="-L/usr/local/lib" CGO_CFLAGS="-I/usr/local/include" go build
- 	* For a default Homebrew install on an ARM-based Mac:
- 	
-			CGO_LDFLAGS="-L/opt/homebrew/lib" CGO_CFLAGS="-I/opt/homebrew/include" go build
-	* For a customized Homebrew install, modify the above to match your configuration.
+    * For a default Homebrew install on an ARM-based Mac:
+
+            CGO_LDFLAGS="-L/opt/homebrew/lib" CGO_CFLAGS="-I/opt/homebrew/include" go build
+    * For a customized Homebrew install, modify the above to match your configuration.
         
-8.  Run the calblink program:
+10. Run the calblink program:
 
         ./calblink
 
-9.  It will request that you go to a URL. On macOS, it will also request that you allow
+11. It will request that you go to a URL. On macOS, it will also request that you allow
     the program to receive network requests; you should allow this.  You should access
     this URL from the account you want to read the calendar of.
 
-10. That's it! It should just run now, and set your blink(1) to change color
+12. That's it! It should just run now, and set your blink(1) to change color
     appropriately. To quit out of it, hit Ctrl-C in the window you ran it in.
     (It will turn the blink(1) off automatically.) It will output a . into the
     terminal window every time it checks the server and sets the LED.
 
-11. Optionally, set up a config file, as below.
+13. Optionally, set up a config file, as below.
 
-12. Once everything is working, you can consider enabling [service mode](SERVICE.md) to
+14. Once everything is working, you can consider enabling [service mode](SERVICE.md) to
     have it run automatically in the background.
 
 ## What are the configuration options?

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ To use calblink, you need the following:
 7.  Get an OAuth 2 ID as described in step 1 of the [Google Calendar
     Quickstart](https://developers.google.com/google-apps/calendar/quickstart/go).
     Put the client\_secret.json file in your GOPATH directory.
+    
+7.  Make sure the client\_secret.json file is secure by changing its permissions
+    to only allow the user to read it:
+    
+        chmod 600 client_secret.json
 
 8.  Build the calblink program as appropriate for your environment:
     * For a Linux environment or another that doesn't use Homebrew:
@@ -76,6 +81,9 @@ To use calblink, you need the following:
     terminal window every time it checks the server and sets the LED.
 
 11. Optionally, set up a config file, as below.
+
+12. Once everything is working, you can consider enabling [service mode](SERVICE.md) to
+    have it run automatically in the background.
 
 ## What are the configuration options?
 
@@ -185,6 +193,7 @@ To comply with the new security measure and meet the new requirements, please fo
 ## Known Issues
 
 *   Occasionally the shutdown is not as clean as it should be.
+*   Something seems to cause an occasional crash.
 *   If the blink(1) becomes disconnected, sometimes the program crashes instead of failing
     gracefully.
 
@@ -214,4 +223,6 @@ To comply with the new security measure and meet the new requirements, please fo
 *   Calblink contains code from the [Google Calendar API
     Quickstart](https://developers.google.com/google-apps/calendar/quickstart/go)
     which is licensed under the Apache 2 license.
+*   Calblink uses the [Go service](https://github.com/kardianos/service/) library for
+    managing service mode.
 *   All trademarks are the property of their respective holders.

--- a/SERVICE.md
+++ b/SERVICE.md
@@ -1,0 +1,47 @@
+# Running calblink as a service
+
+## What does this do?
+
+Calblink now supports a mode where it runs as a service.  This means that it is managed
+by your operating system instead of needing to manually run it.  This service can be
+turned on and survive reboots.
+
+## What operating systems does this mode support?
+
+It has only been tested on macOS.  Theoretically it should work on Linux and other
+Unix-style operating systems, and might possibly work on Windows.  Try it out and if
+you have issues, let me know.
+
+## What potential problems are there for this mode?
+
+calblink currently doesn't cope well with not having a blink(1) installed when it is run.
+It will exit after enough failures to control the blink(1), if it doesn't segfault first.
+This mode works best for cases where a machine has a blink(1) set up at all times.
+Alternately, if you have a way of controlling launch daemons based on USB events
+(EventScripts or similar on macOS) you can use that to only run calblink when there
+is a blink(1) plugged in.
+
+If you don't disable the launch daemon when there isn't a blink(1) plugged in, calblink
+will crash and be automatically restarted every ten seconds or so.
+
+## How do I set this up?
+
+These instructions assume macOS.
+
+1.  Install calblink like you normally would, then make sure your configuration
+    is set up the way you want.
+2.  Run calblink as follows:
+
+        ./calblink -runAsService -service install
+        
+    This will install a launch agent in ~/Library/LaunchAgents.
+3.  You can then control it with launchctl like any other launch agent, or run
+    calblink to control the agent:
+
+        ./calblink -runAsService -service start
+        
+    Available commands include `start`, `stop`, `restart`, `install`, and `uninstall`.
+4.  Log messages will go into your home directory, in `calblink.out.log` and
+    `calblink.err.log`.  Unless debug is turned on, there should be minimal logging.
+    One log line is created at startup and shutdown, and fatal errors will be logged
+    to the error log.

--- a/blinker.go
+++ b/blinker.go
@@ -113,6 +113,10 @@ func (blinker *BlinkerState) reinitialize() error {
 	return err
 }
 
+func (blinker *BlinkerState) turnOff() {
+	blinker.device.SetState(blink1.OffState)
+}
+
 func (blinker *BlinkerState) setState(state blink1.State) error {
 	if blinker.failures > 0 {
 		err := blinker.reinitialize()
@@ -232,8 +236,7 @@ func signalHandler(blinker *BlinkerState) {
 			continue
 		}
 		if blinker.failures == 0 {
-			blinker.newState <- Black
-			blinker.device.SetState(blink1.OffState)
+			blinker.turnOff()
 		}
 		log.Fatalf("Quitting due to signal %v", s)
 	}

--- a/calblink.go
+++ b/calblink.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -38,8 +37,8 @@ var showDotsFlag = flag.Bool("show_dots", true, "Whether to show progress dots a
 var runAsServiceFlag = flag.Bool("runAsService", false, "Whether to run as a service or remain live in the current shell")
 var serviceFlag = flag.String("service", "", "Control the system service.")
 
-var debugOut io.Writer = ioutil.Discard
-var dotOut io.Writer = ioutil.Discard
+var debugOut io.Writer = io.Discard
+var dotOut io.Writer = io.Discard
 
 // Necessary status for running as a service
 type program struct {

--- a/network.go
+++ b/network.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -49,7 +48,7 @@ func loadClientCredentials(clientSecretPath string) ([]byte, error) {
 		return nil, fmt.Errorf("insecure permissions for client secret file: %s", clientSecretPath)
 	}
 	// Read the contents of the file
-	content, err := ioutil.ReadFile(clientSecretPath)
+	content, err := os.ReadFile(clientSecretPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read client secret file: %v", err)
 	}

--- a/network.go
+++ b/network.go
@@ -45,7 +45,7 @@ func loadClientCredentials(clientSecretPath string) ([]byte, error) {
 		return nil, fmt.Errorf("client secret file not found: %s", clientSecretPath)
 	}
 	// Check if the file has secure permissions (readable only by owner)
-	if info.Mode().Perm() & 077 != 0 {
+	if info.Mode().Perm()&077 != 0 {
 		return nil, fmt.Errorf("insecure permissions for client secret file: %s", clientSecretPath)
 	}
 	// Read the contents of the file

--- a/service.go
+++ b/service.go
@@ -34,7 +34,7 @@ func (p *program) StartService(serviceCmd string) {
 		Description:      "Service to monitor Google Calendar to control a blink(1)",
 		Arguments:        []string{"-runAsService"},
 		WorkingDirectory: dir,
-		Option:           service.KeyValue {
+		Option: service.KeyValue{
 			"UserService": true,
 		},
 	}

--- a/service.go
+++ b/service.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file manages running calblink as a service.
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/kardianos/service"
+)
+
+func (p *program) StartService(serviceCmd string) {
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	svcConfig := &service.Config{
+		Name:             "calblink",
+		DisplayName:      "calblink",
+		Description:      "Service to monitor Google Calendar to control a blink(1)",
+		Arguments:        []string{"-runAsService"},
+		WorkingDirectory: dir,
+		Option:           service.KeyValue {
+			"UserService": true,
+		},
+	}
+	s, err := service.New(p, svcConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	p.service = s
+	if len(serviceCmd) != 0 {
+		err := service.Control(s, serviceCmd)
+		if err != nil {
+			log.Printf("Valid actions: %q\n", service.ControlAction)
+			log.Fatal(err)
+		}
+		return
+	}
+	err = s.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p *program) Start(s service.Service) error {
+	go runLoop(p)
+	return nil
+}
+
+func (p *program) Stop(s service.Service) error {
+	close(p.exit)
+	return nil
+}


### PR DESCRIPTION
This also includes one major change and one minor change caused
by this, and integrates changes from https://github.com/google/calblink/pull/57.

Major change: instead of sleeping for 30 seconds (or, during
skip time, up to five minutes), calblink now uses a one-second
timer.  An internal check is made of when the next API call
is needed, so this will reduce the number of API calls made
and increase fidelity in the case where a device is slept.

Minor change: In service mode, the launch header (with the
settings resulting from parsing the config file) will
be skipped and showDots will be forced off.

The pull request removes the obsolete ioutil package, and cleans up
the README.md file.